### PR TITLE
fix uninitialised variable

### DIFF
--- a/exploring-cpp-2e/chapter42/list4204.cpp
+++ b/exploring-cpp-2e/chapter42/list4204.cpp
@@ -5,6 +5,6 @@
 int main()
 {
   std::vector<int> vec(10);
-  int state;
+  int state {0};
   std::generate(vec.begin(), vec.end(), [&state]() { return ++state; });
 }


### PR DESCRIPTION
the 0 is not necessary (the braces are) but make the code IMHO clearer.

There is no excuse to not initialize, as the text says:
"For example, a vector of size 10 would contain the values 1, 2, 3, . . . , 8, 9, 10".

Unfortunately, the compiler does not warn and valgrind does not report, as nothing happens with the vector and the compiler seems to happily remove it.